### PR TITLE
DX-267 - Remove unused UnoCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitepress-shopware-docs",
-  "version": "0.2.0-beta.8",
+  "version": "0.2.0-beta.9",
   "description": "Vitepress theme for Shopware",
   "main": "src/index.ts",
   "exports": {

--- a/src/shopware/components/CodeBlock.vue
+++ b/src/shopware/components/CodeBlock.vue
@@ -9,7 +9,7 @@ let title = ref(attrs.title);
 <template>
     <div class="mb-14">
         <div v-if="title" class="flex gap-3 items-center font-mono text-xs bg-gray-100 dark:bg-#313131 py-3 px-5 rounded-md">
-            <div i-carbon-document class="h-6 w-6" />
+            <div class="i-carbon-document h-6 w-6" />
             {{ title }}
         </div>
         <div class="mb--7 mt--4">

--- a/src/shopware/components/PageRef.vue
+++ b/src/shopware/components/PageRef.vue
@@ -8,7 +8,7 @@
           <img :src="icon" class="w-14 h-14 object-cover" />
         </div>
         <div v-else-if="video">
-          <div i-carbon-logo-youtube class="h-7 w-7 text-shopware" />
+          <div class="i-carbon-logo-youtube h-7 w-7 text-shopware" />
         </div>
         <div class="flex-1">
           {{ title }}

--- a/src/vitepress/config/baseConfig.js
+++ b/src/vitepress/config/baseConfig.js
@@ -7,13 +7,8 @@
 const Unocss = require("unocss/vite");
 const {
   defineConfig,
-  presetAttributify,
   presetIcons,
-  presetTypography,
   presetUno,
-  presetWebFonts,
-  transformerDirectives,
-  transformerVariantGroup,
 } = require("unocss");
 
 // remove navigation from the library
@@ -43,24 +38,13 @@ module.exports = async () => withMermaid({
     plugins: [
       Unocss.default(
         defineConfig({
-          shortcuts: [["text-shopware", "text-#0489EA"]],
           presets: [
             presetUno(),
-            presetAttributify(),
             presetIcons({
               scale: 1.2,
               warn: true,
             }),
-            presetTypography(),
-            presetWebFonts({
-              fonts: {
-                sans: "DM Sans",
-                serif: "DM Serif Display",
-                mono: "DM Mono",
-              },
-            }),
           ],
-          transformers: [transformerDirectives(), transformerVariantGroup()],
         })
       ),
     ],

--- a/src/vitepress/config/baseConfig.js
+++ b/src/vitepress/config/baseConfig.js
@@ -38,6 +38,7 @@ module.exports = async () => withMermaid({
     plugins: [
       Unocss.default(
         defineConfig({
+          shortcuts: [["text-shopware", "text-#0489EA"]],
           presets: [
             presetUno(),
             presetIcons({


### PR DESCRIPTION
This PR removes unused (and buggy) UnoCSS features for better compatibility with the new docs: `presetAttributify`, `presetTypography`, `presetWebFonts`, `transformerDirectives` and `transformerVariantGroup`.

See https://github.com/unocss/unocss/issues/2112 and https://github.com/unocss/unocss/issues/2106 for more info.