### PR TITLE
DX-286 - Show 2nd (3rd) level headings in the outline

### DIFF
--- a/src/vitepress/components/VPContentDocOutline.vue
+++ b/src/vitepress/components/VPContentDocOutline.vue
@@ -38,7 +38,7 @@ const handleClick = ({ target: el }: Event) => {
           <a class="outline-link" :href="link" @click="handleClick">{{
             text
           }}</a>
-          <ul v-if="children && frontmatter.outline === 'deep'">
+          <ul v-if="children && frontmatter.outline !== 'shallow'">
             <li v-for="{ text, link, hidden } in children" v-show="!hidden">
               <a
                 class="outline-link nested"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/117360292/224079069-3e098fcc-804a-42ce-9a9c-859c0d24c94e.png)
