### PR TITLE
DX-288 - Versioned sidebars

### DIFF
--- a/src/core/composables/Sidebar.ts
+++ b/src/core/composables/Sidebar.ts
@@ -359,6 +359,12 @@ export function transformLinkToSidebar(root: string, link: string) {
                     return reduced;
                 }
 
+                // skip versioned folders
+                const versionRegex = /^v\d+\.\d+$/;
+                if (file.match(versionRegex)) {
+                    return reduced;
+                }
+
                 let hasIndex = false;
                 if (!fs.statSync(`${folder}${file}`).isDirectory()) {
                     // skip non .md files

--- a/src/vitepress/support/sidebar.ts
+++ b/src/vitepress/support/sidebar.ts
@@ -17,12 +17,21 @@ export function getSidebar(
 
   path = ensureStartingSlash(path)
 
+  const sidebars = {};
   for (const dir in sidebar) {
     // make sure the multi sidebar key starts with slash too
     if (path.startsWith(ensureStartingSlash(dir))) {
-      return sidebar[dir]
+      sidebars[dir] = sidebar[dir];
     }
   }
 
-  return []
+  if (!Object.keys(sidebars).length) {
+    return []
+  }
+
+  let maxKey = Object.keys(sidebars).sort(function(a, b){
+    return b.length - a.length;
+  })[0];
+
+  return sidebars[maxKey];
 }


### PR DESCRIPTION
This PR updates the behaviour for when multiple leveled (versioned) sidebars are defined. It:
 - hides versioned sidebars from the parent sidebar (for example, it hides `docs/v6.4` from `docs/`)
 - shows sub-sidebar in the child sidebar (for example, it shows `docs/v6.4` on URL `/docs/v6.4`/)