### PR TITLE
Fix svg in footer link is displayed white instead of text color

### DIFF
--- a/src/shopware/components/SwagFooter.vue
+++ b/src/shopware/components/SwagFooter.vue
@@ -95,7 +95,7 @@
 
 .SwagFooter_links {
   svg {
-    fill: #fff;
+    fill: currentColor;
   }
 }
 


### PR DESCRIPTION
StackOverflow icon is not like other icons next to it. Works also on hover.

Before:
![image](https://github.com/user-attachments/assets/20a735a5-020a-4aea-971e-dfdf64e8f545)

After:
![image](https://github.com/user-attachments/assets/e4652904-a4a6-431a-8f19-e840333064a5)
